### PR TITLE
Changing `Plugin` to `Plug` in .vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ keyword, for C++ for example).
 Vundle : Add this to .vimrc
 
 ```vim
-Plugin 'frazrepo/vim-rainbow'
+Plug 'frazrepo/vim-rainbow'
 ```
 
 # Simple Configuration


### PR DESCRIPTION
I am using vim-plug. Using `Plugin 'frazrepo/vim-rainbow'` to add the repo name throws `Not an editor command: Plugin 'frazrepo/vim-rainbow'`.
I believe the correct keyword is `Plug`, which works fine for me.